### PR TITLE
Generalize deploy.sh from working directory

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -eo pipefail
 
-npm install
-node app.js
+BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+npm install $BASEDIR
+node $BASEDIR/app.js
 


### PR DESCRIPTION
Right now `deploy.sh` requires you to be in `concierge/`, but now it will have the same effects independent of the working directory.

PTAL @gmittal 