### PR TITLE
Add fade when user goes back to a previous question

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -151,7 +151,9 @@
         currentQuestion = prev.currentIndex;
         questionQueue = prev.queue.slice();
 
-        helper.text(prev.helper);
+        helper.fadeOut(200, function() {
+          helper.text(prev.helper);
+        }).fadeIn(200);
 
         if (ix == 1) {
           mainInput[0].css('display', 'none');


### PR DESCRIPTION
Thought we should have a similar animation when the user goes forward and backward one question. Previously there was only a fade when the user went forward. 

@ankitr PTAL.